### PR TITLE
Change `in_current_file` --> `in_current_file'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ but already usable for fun.
 
 ## Installation
 
-You need Python 3.6 or later, and Lean 3.4. Make sure the python package
+You need Python 3.6 or later, and Lean 3.26. Make sure the python package
 manager `pip` is installed.  Clone this repository, go to its root directory
 and run `pip install .` (using `sudo` if needed). It's also recommended to
 install `ipython` for interactive use. Alternatively, if you don't want to mess

--- a/src/leancrawler/deps.lean
+++ b/src/leancrawler/deps.lean
@@ -219,7 +219,7 @@ meta def print_content : tactic unit :=
 do curr_env ← get_env,
    let decls := curr_env.fold [] list.cons,
    let local_decls := decls.filter
-     (λ x, environment.in_current_file' curr_env (to_name x) && not (to_name x).is_internal),
+     (λ x, environment.in_current_file curr_env (to_name x) && not (to_name x).is_internal),
    local_decls.mmap' (print_item_crawl curr_env)
 
 meta def print_all_content : tactic unit :=


### PR DESCRIPTION
Lean's community fork version 3.26 no longer contains `in_current_file'`. Based on remarks in [this PR](https://github.com/leanprover-community/lean/pull/432) I believe the correct fix is to use `in_current_file` instead.