### PR TITLE
Fix proof_i bug

### DIFF
--- a/leancrawler/crawler.lean
+++ b/leancrawler/crawler.lean
@@ -51,9 +51,6 @@ meta def list_type_items (nm₀ : name) : tactic (list name) := do
   l₃ ← aux.mfold l₂ (λ nm l', list_items_aux nm₀ nm >>= λ l'', return (l'.union l'')),
   return l₃.to_list
 
-meta def list_items (e : expr) : list name :=
-e.list_constant'
-
 meta def mnot : bool → tactic bool := λ p, return (¬ p)
 
 meta def pos_line (p : option pos) : string :=


### PR DESCRIPTION
It now gives the correct data on the test.

Note: The special case where `foo` uses `bar._proof_i` without using `bar` directly is still not handled properly, but I think we can ignore that case.

I did not really test it beyond the single example.